### PR TITLE
[Bugfix] Enable multiple plugins

### DIFF
--- a/commands/rabbitmq/rabbitmq
+++ b/commands/rabbitmq/rabbitmq
@@ -123,7 +123,7 @@ case $CMD in
 
     plugins_array=$(yq eval '.plugins[]' "$YAML_FILE")
     plugins=$(echo "${plugins_array[*]}" | tr '\n' ' ' | xargs)
-    rabbitmq-plugins enable "$plugins"
+    rabbitmq-plugins enable $plugins
 
     add_vhosts
     # Ensure the default admin "rabbitmq" has permissions for all virtual hosts


### PR DESCRIPTION
When adding multiple plugins in `.ddev/rabbitmq/config.yaml` (e.g. "rabbitmq_management" and "rabbitmq_consistent_hash_exchange") the command `ddev rabbitmq apply` will output the following:

> {:plugins_not_found, [:"rabbitmq_management rabbitmq_consistent_hash_exchange"]}

The `rabbitmq-plugins enable "$plugins"` command interprets the string of plugins as one plugin because of the double quotes. By removing the quotes each plugin will be recognised as a separate plugin.