### PR TITLE
[Bugfix] Config for vhosts, queues, users, and plugins live in `rabbitmq/config.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For more details check the connection section below.
 
 ### YAML configuration
 
-The [config.rabbitmq.yaml](config.rabbitmq.yaml) describes
+The [rabbitmq/config.yaml](rabbitmq/config.yaml) describes
 vhosts, queues, users, and plugins.
 
 The configuration can be applied with the following command:


### PR DESCRIPTION
The config for vhosts, queues, users, and plugins live in `rabbitmq/config.yaml`, not in `config.rabbitmq.yaml`.