### PR TITLE
refactor: use `#!/usr/bin/env bash` instead of `#!/bin/bash`

### DIFF
--- a/commands/rabbitmq/rabbitmq
+++ b/commands/rabbitmq/rabbitmq
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 #ddev-generated
 
 ## Description: Manage parts of rabbitmq

--- a/commands/rabbitmq/rabbitmqadmin
+++ b/commands/rabbitmq/rabbitmqadmin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #ddev-generated
 
 ## Description: Manage parts of rabbitmq

--- a/commands/rabbitmq/rabbitmqctl
+++ b/commands/rabbitmq/rabbitmqctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #ddev-generated
 
 ## Description: Manage parts of rabbitmq


### PR DESCRIPTION
## The Issue

`#!/bin/bash` is not supported by NixOS.

## How This PR Solves The Issue

Uses `#!/usr/bin/env bash`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

