### PR TITLE
[TASK] Add "launch" subcommand to "rabbitmq"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ ddev rabbitmq wipe
 
 ## Usage
 
-| Command | Description |
-| ------- | ----------- |
-| `ddev rabbitmq --help` | RabbitMQ custom helper command |
-| `ddev rabbitmqadmin --help` | RabbitMQ Management CLI (no auth required) |
-| `ddev rabbitmqctl --help` | Used to manage the cluster and nodes |
-| `ddev launch :15673` | Run RabbitMQ Management UI in the browser (credentials `rabbitmq:rabbitmq`) |
-| `ddev describe` | View service status and used ports for RabbitMQ |
-| `ddev logs -s rabbitmq` | Check RabbitMQ logs |
+| Command                     | Description                                                                    |
+|-----------------------------|--------------------------------------------------------------------------------|
+| `ddev rabbitmq --help`      | RabbitMQ custom helper command                                                 |
+| `ddev rabbitmqadmin --help` | RabbitMQ Management CLI (no auth required)                                     |
+| `ddev rabbitmqctl --help`   | Used to manage the cluster and nodes                                           |
+| `ddev rabbitmq launch`      | Launch RabbitMQ Management UI in the browser (credentials `rabbitmq:rabbitmq`) |
+| `ddev describe`             | View service status and used ports for RabbitMQ                                |
+| `ddev logs -s rabbitmq`     | Check RabbitMQ logs                                                            |
 
 ℹ️`rabbitmqadmin` and `rabbitmqctl` share some functions. Both are needed for full configuration.
 

--- a/commands/host/rabbitmq
+++ b/commands/host/rabbitmq
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#ddev-generated
+
+## Description: A host wrapper command for rabbitmq/rabbitmq to enhance the command with "launch" capabilities
+## Usage: rabbitmq
+## Example: ddev rabbitmq
+
+CMD=$1
+
+launch_rabbitmq_gui() {
+    echo "Launching RabbitMQ Management UI..."
+    echo "Login using 'rabbitmq' user and 'rabbitmq' password."
+
+    rabbitmq_port=$(ddev exec "yq '.services.rabbitmq.expose[0]' .ddev/docker-compose.rabbitmq.yaml")
+    ddev launch :$rabbitmq_port
+}
+
+case $CMD in
+  launch)
+    launch_rabbitmq_gui
+    ;;
+  *)
+    # Run script within service container and pass in all arguments
+    ddev exec -s rabbitmq /mnt/ddev_config/commands/rabbitmq/rabbitmq $@
+    ;;
+esac

--- a/commands/host/rabbitmq
+++ b/commands/host/rabbitmq
@@ -24,7 +24,17 @@ case $CMD in
     launch_rabbitmq_gui
     ;;
   *)
-    # Run script within service container and pass in all arguments
-    ddev exec -s rabbitmq /mnt/ddev_config/commands/rabbitmq/rabbitmq $@
+    if [ "$CMD" = "--help" ] || [ -z "$CMD" ]; then
+        # Output help and display additional information about the "launch" command
+        ddev exec -s rabbitmq /mnt/ddev_config/commands/rabbitmq/rabbitmq --help
+        echo ""
+        echo -e "\033[1mLaunch\033[0m"
+        echo "—————"
+        echo "Launch RabbitMQ Management UI"
+        echo "👉 ddev rabbitmq launch"
+    else
+        # Run the script within service container and pass in all arguments
+        ddev exec -s rabbitmq /mnt/ddev_config/commands/rabbitmq/rabbitmq $@
+    fi
     ;;
 esac

--- a/commands/host/rabbitmq
+++ b/commands/host/rabbitmq
@@ -11,7 +11,11 @@ launch_rabbitmq_gui() {
     echo "Launching RabbitMQ Management UI..."
     echo "Login using 'rabbitmq' user and 'rabbitmq' password."
 
-    rabbitmq_port=$(ddev exec "yq '.services.rabbitmq.expose[0]' .ddev/docker-compose.rabbitmq.yaml")
+    PROTOCOL="HTTP"
+    if [ "${DDEV_PRIMARY_URL%://*}" != "http" ] && [ -z "${GITPOD_WORKSPACE_ID:-}" ] && [ "${CODESPACES:-}" != "true" ]; then
+      PROTOCOL="HTTPS"
+    fi
+    rabbitmq_port=$(ddev exec "yq '.services.rabbitmq.environment.${PROTOCOL}_EXPOSE | split(\":\")[0]' .ddev/.ddev-docker-compose-full.yaml")
     ddev launch :$rabbitmq_port
 }
 

--- a/install.yaml
+++ b/install.yaml
@@ -3,6 +3,7 @@ name: rabbitmq
 project_files:
   - docker-compose.rabbitmq.yaml
   - config.rabbitmq.yaml
+  - commands/host/rabbitmq
   - commands/rabbitmq/
   - rabbitmq/config.yaml
   - rabbitmq/schema.json

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -107,6 +107,11 @@ health_checks() {
   assert_success
   assert_output "pcntl"
 
+  echo "See launch command is working" >&3
+  DDEV_DEBUG=true run ddev rabbitmq launch
+  assert_success
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site:15673"
+
   echo "Remove addon - see files removed" >&3
   expected_files_not_to_exist=(docker-compose.rabbitmq.yaml commands/rabbitmq/rabbitmq commands/rabbitmq/rabbitmqadmin commands/rabbitmq/rabbitmqctl rabbitmq/config.yaml rabbitmq/schema.json)
   for file in "${expected_files_not_to_exist[@]}"; do

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -112,6 +112,14 @@ health_checks() {
   assert_success
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site:15673"
 
+  echo "See --help output" >&3
+  DDEV_DEBUG=true run ddev rabbitmq
+  assert_success
+  assert_output --partial "ddev rabbitmq apply"
+  assert_output --partial "ddev rabbitmq wipe"
+  assert_output --partial "ddev rabbitmq watch <command> <interval>"
+  assert_output --partial "ddev rabbitmq launch"
+
   echo "Remove addon - see files removed" >&3
   expected_files_not_to_exist=(docker-compose.rabbitmq.yaml commands/rabbitmq/rabbitmq commands/rabbitmq/rabbitmqadmin commands/rabbitmq/rabbitmqctl rabbitmq/config.yaml rabbitmq/schema.json)
   for file in "${expected_files_not_to_exist[@]}"; do


### PR DESCRIPTION
## The Issue

It would be handy to launch rabbitmq UI using `ddev rabbitmq launch`. Which calls `ddev launch :<port>` under the hood.

## How This PR Solves The Issue

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-rabbitmq/tarball/task/add-launch-command
ddev restart
```
Then run `ddev rabbitmq launch`. This should open the RabbitMQ management GUI in the browser.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
