### PR TITLE
Fix copy paste error in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ hook to your `.ddev/config.yaml`:
 ```yaml
 hooks:
   post-start:
-    - exec-host: ddev solrctl apply
+    - exec-host: ddev rabbitmq apply
 ```
 
 Remove rabbitmq configuration but keep default user (`rabbitmq`) and vhost (`/`):


### PR DESCRIPTION
Replace the command in the post-start example with the correct command: "ddev rabbitmq apply"

Fixes https://github.com/ddev/ddev-rabbitmq/issues/23