### PR TITLE
fix(docker): use ubuntu image, rabbitmqadmin is missing in alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can access the RabbitMQ service through its AMQP protocol inside any DDEV co
 To change the Docker image:
 
 ```bash
-ddev dotenv set .ddev/.env.rabbitmq --rabbitmq-docker-image="rabbitmq:4-management-alpine"
+ddev dotenv set .ddev/.env.rabbitmq --rabbitmq-docker-image="rabbitmq:4-management"
 ddev add-on get ddev/ddev-rabbitmq
 ddev restart
 ```

--- a/commands/rabbitmq/rabbitmq
+++ b/commands/rabbitmq/rabbitmq
@@ -24,7 +24,7 @@ function watcher() {
 
   if [[ " ${ALLOWED_DISPLAY_ARGUMENTS[*]} " = *" $subcommand "* ]]; then
       while true; do
-          output=$(rabbitmqadmin "$display_argument" -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS")
+          output=$(rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" "$display_argument")
           clear
           echo "$output"
           echo "Refresh interval: $interval sec - $(date)"
@@ -71,7 +71,7 @@ function add_queues() {
 
     if [[ ! " ${queues_existing[*]} " =~ $name ]]; then
       durable=$(echo "$queue" | yq '.durable // "true"' -)
-      rabbitmqadmin declare queue --vhost="$vhost" name="$name" durable="$durable"  -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" || exit 1
+      rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" declare queue --vhost="$vhost" --name="$name" --durable="$durable" || exit 1
     else
       echo "ℹ️ Queue '$name' already exists in vhost '$vhost'! To update the queue please delete it first."
     fi

--- a/commands/rabbitmq/rabbitmq
+++ b/commands/rabbitmq/rabbitmq
@@ -24,7 +24,7 @@ function watcher() {
 
   if [[ " ${ALLOWED_DISPLAY_ARGUMENTS[*]} " = *" $subcommand "* ]]; then
       while true; do
-          output=$(rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" "$display_argument")
+          output=$(rabbitmqadmin "$display_argument")
           clear
           echo "$output"
           echo "Refresh interval: $interval sec - $(date)"
@@ -71,7 +71,7 @@ function add_queues() {
 
     if [[ ! " ${queues_existing[*]} " =~ $name ]]; then
       durable=$(echo "$queue" | yq '.durable // "true"' -)
-      rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" declare queue --vhost="$vhost" --name="$name" --durable="$durable" || exit 1
+      rabbitmqadmin declare queue --vhost="$vhost" --name="$name" --durable="$durable" || exit 1
     else
       echo "ℹ️ Queue '$name' already exists in vhost '$vhost'! To update the queue please delete it first."
     fi

--- a/commands/rabbitmq/rabbitmq
+++ b/commands/rabbitmq/rabbitmq
@@ -108,12 +108,6 @@ function add_users() {
   done
 }
 
-# The RabbitMQ container does not contain yq
-# But it is needed to apply the configuration
-if ! command -v yq >/dev/null 2>&1; then
-    apk add yq > /dev/null 2>&1
-fi
-
 case $CMD in
   apply)
     echo "Apply config $YAML_FILE"

--- a/commands/rabbitmq/rabbitmqadmin
+++ b/commands/rabbitmq/rabbitmqadmin
@@ -5,4 +5,4 @@
 ## Usage: rabbitmqadmin [options] subcommand
 ## Example: ddev rabbitmqadmin --help
 
-rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" $@
+rabbitmqadmin $@

--- a/docker-compose.rabbitmq.yaml
+++ b/docker-compose.rabbitmq.yaml
@@ -3,7 +3,7 @@ services:
   rabbitmq:
     container_name: ddev-${DDEV_SITENAME}-rabbitmq
     hostname: ${DDEV_SITENAME}-rabbitmq
-    image: ${RABBITMQ_DOCKER_IMAGE:-rabbitmq:4-management-alpine}
+    image: ${RABBITMQ_DOCKER_IMAGE:-rabbitmq:4-management}
     expose:
       - 15672
     environment:

--- a/docker-compose.rabbitmq.yaml
+++ b/docker-compose.rabbitmq.yaml
@@ -23,6 +23,8 @@ services:
       - RABBITMQ_DEFAULT_USER=rabbitmq
       - RABBITMQ_DEFAULT_PASS=rabbitmq
       - RABBITMQ_DEFAULT_VHOST=/
+      - RABBITMQADMIN_USERNAME=rabbitmq
+      - RABBITMQADMIN_PASSWORD=rabbitmq
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}

--- a/docker-compose.rabbitmq.yaml
+++ b/docker-compose.rabbitmq.yaml
@@ -3,7 +3,16 @@ services:
   rabbitmq:
     container_name: ddev-${DDEV_SITENAME}-rabbitmq
     hostname: ${DDEV_SITENAME}-rabbitmq
-    image: ${RABBITMQ_DOCKER_IMAGE:-rabbitmq:4-management}
+    image: ${RABBITMQ_DOCKER_IMAGE:-rabbitmq:4-management}-${DDEV_SITENAME}-built
+    build:
+      dockerfile_inline: |
+        ARG RABBITMQ_DOCKER_IMAGE="scratch"
+        FROM $${RABBITMQ_DOCKER_IMAGE}
+        RUN command -v apk >/dev/null 2>&1 || { (apt-get update || true) && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*; }
+        ARG TARGETARCH
+        RUN command -v apk >/dev/null 2>&1 && apk add --no-cache yq || { curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$${TARGETARCH}" -o /usr/bin/yq && chmod +x /usr/bin/yq; }
+      args:
+        RABBITMQ_DOCKER_IMAGE: ${RABBITMQ_DOCKER_IMAGE:-rabbitmq:4-management}
     expose:
       - 15672
     environment:


### PR DESCRIPTION
## The Issue

Tests are failing:

https://github.com/ddev/ddev-rabbitmq/actions/runs/20225666938/job/58056388832#step:2:269

```
#   /mnt/ddev_config/commands/rabbitmq/rabbitmq: line 74: rabbitmqadmin: command not found
```

## How This PR Solves The Issue

1. Switches to Ubuntu based image.

    https://github.com/docker-library/rabbitmq/blob/e2fb2631582a5be1884c4d71012ac3abadb3feaf/4.2/alpine/management/Dockerfile#L18

   > rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588

2. `rabbitmqadmin` got major update https://github.com/rabbitmq/rabbitmqadmin-ng/releases/tag/v2.0.0

    This PR adds `RABBITMQADMIN_USERNAME` and `RABBITMQADMIN_PASSWORD`

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-rabbitmq/tarball/20251215_stasadev_rabbitmqadmin
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
