### PR TITLE
chore(*): run update-checker.sh, version constraint v1.24.10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Exclude files from releases/tarballs
+tests/ export-ignore
+.github/ export-ignore
+.gitattributes export-ignore

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,19 @@
 ## The Issue
 
-- #<issue number>
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
 
 <!-- Provide a brief description of the issue. -->
 
 ## How This PR Solves The Issue
 
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
 ## Manual Testing Instructions
 
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
 ```bash
-ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
+ddev add-on get https://github.com/ddev/ddev-rabbitmq/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,15 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
 
   schedule:
-  - cron: '25 08 * * *'
+    - cron: '25 08 * * *'
 
   workflow_dispatch:
     inputs:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ ddev restart
 
 Make sure to commit the `.ddev/.env.rabbitmq` file to version control.
 
+All customization options (use with caution):
+
+| Variable | Flag | Default |
+| -------- | ---- | ------- |
+| `RABBITMQ_DOCKER_IMAGE` | `--rabbitmq-docker-image` | `rabbitmq:4-management` |
+
 ## Examples
 
 * [TYPO3](USAGE.md)

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,4 +1,4 @@
-# TYPO3 and RabbitMQ 
+# TYPO3 and RabbitMQ
 
 This is just a simple example on how RabbitMQ can be used
 along with TYPO3.
@@ -69,7 +69,7 @@ class RunTheRabbit implements MiddlewareInterface
     ): ResponseInterface {
         $value = ['some' => 'value'];
         $this->bus->dispatch(new MyMessage($value));
-        
+
         return $handler->handle($request);
     }
 }

--- a/docker-compose.rabbitmq.yaml
+++ b/docker-compose.rabbitmq.yaml
@@ -32,6 +32,11 @@ services:
       - "rabbitmq:/var/lib/rabbitmq/mnesia"
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
+    x-ddev:
+      describe-info: |
+        User: rabbitmq
+        Pass: rabbitmq
+      ssh-shell: bash
 
 volumes:
   rabbitmq:

--- a/install.yaml
+++ b/install.yaml
@@ -8,4 +8,4 @@ project_files:
   - rabbitmq/config.yaml
   - rabbitmq/schema.json
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'


### PR DESCRIPTION
## The Issue

```
curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
```

## How This PR Solves The Issue

Adds:

```yaml
services:
  rabbitmq:
    x-ddev:
      describe-info: |
        User: rabbitmq
        Pass: rabbitmq
      ssh-shell: bash
```

Adds version constraint v1.24.10.

Updates add-on files.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-rabbitmq/tarball/refs/pull/26/head
ddev restart
ddev describe # see User: rabbitmq
ddev ssh -s rabbitmq # see bash
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
