### PR TITLE
test: make assertions without relying on order

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -14,6 +14,7 @@
 
 setup() {
   set -eu -o pipefail
+  bats_require_minimum_version 1.5.0
 
   # Override this variable for your add-on:
   export GITHUB_REPO=ddev/ddev-rabbitmq
@@ -70,8 +71,13 @@ health_checks() {
   echo "See expected users" >&3
   run ddev rabbitmqctl list_users --silent --formatter json
   assert_success
-  assert_output --partial '{"user":"rabbitmq","tags":["administrator"]}'
-  assert_output --partial '{"user":"ddev-admin","tags":["administrator,management"]}'
+  _users="$output"
+  run grep '"user":"rabbitmq"' <<< "$_users"
+  assert_success
+  assert_output --partial '"tags":["administrator"]'
+  run grep '"user":"ddev-admin"' <<< "$_users"
+  assert_success
+  assert_output --partial '"tags":["administrator,management"]'
 
   echo "See expected vhosts" >&3
   run ddev rabbitmqctl list_vhosts --silent --formatter json
@@ -82,8 +88,17 @@ health_checks() {
   echo "See expected permissions for users in vhost=ddev-vhost" >&3
   run ddev rabbitmqctl list_permissions --silent --formatter json --vhost=ddev-vhost
   assert_success
-  assert_output --partial '{"user":"ddev-admin","configure":".*","write":".*","read":".*"}'
-  assert_output --partial '{"user":"rabbitmq","configure":".*","write":".*","read":".*"}'
+  _permissions="$output"
+  run grep '"user":"ddev-admin"' <<< "$_permissions"
+  assert_success
+  assert_output --partial '"configure":".*"'
+  assert_output --partial '"write":".*"'
+  assert_output --partial '"read":".*"'
+  run grep '"user":"rabbitmq"' <<< "$_permissions"
+  assert_success
+  assert_output --partial '"configure":".*"'
+  assert_output --partial '"write":".*"'
+  assert_output --partial '"read":".*"'
 
   echo "Delete/wipe custom configuration" >&3
   run ddev rabbitmq wipe
@@ -92,8 +107,12 @@ health_checks() {
   echo "See only rabbitmq default user" >&3
   run ddev rabbitmqctl list_users --silent --formatter json
   assert_success
-  assert_output --partial '{"user":"rabbitmq","tags":["administrator"]}'
-  refute_output --partial '{"user":"ddev-admin","tags":["administrator,management"]}'
+  _users="$output"
+  run grep '"user":"rabbitmq"' <<< "$_users"
+  assert_success
+  assert_output --partial '"tags":["administrator"]'
+  run grep '"user":"ddev-admin"' <<< "$_users"
+  assert_failure
 
   echo "See only '/' vhost exists" >&3
   run ddev rabbitmqctl list_vhosts --silent --formatter json


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev-rabbitmq/actions/runs/24881564545/job/72851013702#step:2:231

```
not ok 1 install from directory
# (from function `assert_output' in file /home/linuxbrew/.linuxbrew/lib/bats-assert/src/assert_output.bash, line 186,
#  from function `health_checks' in file tests/test.bats, line 85,
#  in test file tests/test.bats, line 164)
#   `health_checks' failed
#
# -- output does not contain substring --
# substring (1 lines):
#   {"user":"ddev-admin","configure":".*","write":".*","read":".*"}
# output (4 lines):
#   [
#   {"user":"ddev-admin","read":".*","write":".*","configure":".*"}
#   ,{"user":"rabbitmq","read":".*","write":".*","configure":".*"}
#   ]
# --
#
```

## How This PR Solves The Issue

Fixes the test.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-rabbitmq/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
